### PR TITLE
move self.update() out of the loop that steps through effects

### DIFF
--- a/python/mp/rosary.py
+++ b/python/mp/rosary.py
@@ -347,7 +347,8 @@ class Rosary:
                 effect.next(self)
                 if (effect.finished):
                     self.del_effect(effect.id)
-                self.update()
+
+            self.update()
 
             # Let the triggers figure out for themselves what to do
             for trigger in self.triggers.values():


### PR DESCRIPTION
...so update() runs only one time every time around the mainloop. this should stop the lights from flickering when multiple effects are running, since there will be only one update after all the effects run next().