### PR TITLE
add set_bead_set_cc() to effect.py

### DIFF
--- a/python/mp/effects/effect.py
+++ b/python/mp/effects/effect.py
@@ -56,6 +56,23 @@ class Effect(abc.ABC):
         beads.sort(key=lambda bead: bead.index)
         self.bead_list = beads
 
+    def set_bead_set_cc(self, set):
+        """Convenience function for storing a set of beads as a sorted list in
+        a counter-clockwise direction."""
+        bead_map = [0, 1, 2, 3, 4,
+                    59, 58, 57, 56, 55, 54, 53, 52, 51, 50,
+                    49, 48, 47, 46, 45, 44, 43, 42, 41, 40,
+                    39, 38, 37, 36, 35, 34, 33, 32, 31, 30,
+                    29, 28, 27, 26, 25, 24, 23, 22, 21, 20,
+                    19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
+                    9, 8, 7, 6, 5]
+
+        beads = []
+        for bead in set:
+            beads.append(bead)
+        beads.sort(key=lambda bead: bead_map[bead.index])
+        self.bead_list = beads
+
     def get_name(self):
         """Returns the name of the Effect."""
         return self.name


### PR DESCRIPTION
this causes the "next" bead to go around the loop counter-clockwise after leaving the "stem"

example from interactive session:
>>> r.add_effect('bounce')
1
>>> r.effect(1).set_bead_set_cc(r.set_registry['all'])