### PR TITLE
Jdb colormap

### DIFF
--- a/python/mp/color.py
+++ b/python/mp/color.py
@@ -94,7 +94,7 @@ class ColorMap(Color):
         self.colormap = colormap
 
     def __repr__(self):
-        return "ColorMap(color=Color(r={}, g={}, b={}, a={}), colormap={})".format(self.r, self.g, self.b, self.a, self.colormap)
+        return "ColorMap(r={}, g={}, b={}, a={}, colormap={})".format(self.r, self.g, self.b, self.a, self.colormap)
 
 
     def map(self, value):
@@ -149,7 +149,7 @@ class ColorMapFade(Color):
         self.delta_t = 1 / time
 
     def __repr__(self):
-        return "ColorMap(color=Color(r={}, g={}, b={}, a={}), colormap={}, time={})".format(self.r, self.g, self.b, self.a, self.colormap, self.time)
+        return "ColorMap(r={}, g={}, b={}, a={}, colormap={}, time={})".format(self.r, self.g, self.b, self.a, self.colormap, self.time)
 
     def next(self):
         self.delta += self.delta_t
@@ -180,3 +180,5 @@ class ColorFade(ColorMapFade):
     def next(self):
         super().next()
 
+
+rainbow_map = [ColorMapStep(0, Color(1, 0, 0)), ColorMapStep(1/3, Color(0, 1, 0)), ColorMapStep(2/3, Color(0, 0, 1)), ColorMapStep(1, Color(1, 0, 0))]

--- a/python/mp/color.py
+++ b/python/mp/color.py
@@ -1,3 +1,6 @@
+from collections import namedtuple
+
+
 class Color:
     """Color represents the color of an individual bead."""
     
@@ -7,6 +10,7 @@ class Color:
         self.b = b  # blue
         self.a = a  # alpha channel (not yet used)
         self.brightness = 0xff;  # brightness used by APA102 LED module
+        self.name = name
 
     def __repr__(self):
         return "Color({}, {}, {}, {})".format(self.r, self.g, self.b, self.a)
@@ -47,7 +51,91 @@ class Color:
         pass
 
 
-class ColorFade(Color):
+
+ColorMapStep = namedtuple('ColorMapStep', 'step color')
+
+
+class ColorMap(Color):
+    """
+    Defines a linear color map, mapping a range to a color.
+    By convention I expect we will use the range (0,1) but any range is possible.
+
+    The map is defined as an array of ColorMapStep, which maps a value to a color.
+    If the value we map is between two ColorMapStep the linear interpolation is calculated.
+
+    The ColorMap is a Color object - you can set r, g, b and a just like any other Color object.
+    However, it is intended that the color is set using map(), which maps a value in the
+    defined range to a color.
+    """
+
+    def __init__(self, colormap=[ColorMapStep(0, Color(0, 0, 0)), ColorMapStep(1, Color(1, 1, 1))]):
+        super().__init__(r=colormap[0].color.r, g=colormap[0].color.g, b=colormap[0].color.b, a=colormap[0].color.a, name='color_map')
+        self.colormap = colormap
+
+    def __repr__(self):
+        return "ColorMap(color=Color(r={}, g={}, b={}, a={}), colormap={})".format(self.r, self.g, self.b, self.a, self.colormap)
+
+
+    def map(self, value):
+
+        def interpolate(x0, y0, x1, y1, xv):
+            if (y0 == y1):
+                return y0
+
+            return y0 + (( (y1 - y0) / (x1 - x0) ) * (xv - x0))
+
+        # first check lower bound
+        if (value <= self.colormap[0].step):
+            self.set(self.colormap[0].color)
+            return
+
+        # then upper bound
+        if (value >= self.colormap[-1].step):
+            self.set(self.colormap[-1].color)
+            return
+
+        # now search for steps to interpolate color between
+        m0 = self.colormap[0]
+        for m1 in self.colormap[1:]:
+            # check easy case before doing math
+            if (value == m1.step):
+                self.set(m1.color)
+                return
+
+            if (value < m1.step):
+                # interpolate color
+                self.r = interpolate(m0.step, m0.color.r, m1.step, m1.color.r, value)
+                self.g = interpolate(m0.step, m0.color.g, m1.step, m1.color.g, value)
+                self.b = interpolate(m0.step, m0.color.b, m1.step, m1.color.b, value)
+                self.a = interpolate(m0.step, m0.color.a, m1.step, m1.color.a, value)
+                return
+
+            m0 = m1
+
+
+class ColorMapFade(Color):
+    def __init__(self, colormap=ColorMap(colormap=[ColorMapStep(0, Color(0, 0, 0)), ColorMapStep(1, Color(1, 1, 1))]), time=30, name='color_map_fade'):
+        super().__init__(r=colormap.colormap[0].color.r,
+                         g=colormap.colormap[0].color.g,
+                         b=colormap.colormap[0].color.b,
+                         a=colormap.colormap[0].color.a, name=name)
+        self.colormap = colormap
+        self.delta = 0
+        self.time = time
+        self.delta_t = 1 / time
+
+    def __repr__(self):
+        return "ColorMap(color=Color(r={}, g={}, b={}, a={}), colormap={}, time={})".format(self.r, self.g, self.b, self.a, self.colormap, self.time)
+
+    def next(self):
+        self.delta += self.delta_t
+        self.colormap.map(self.delta)
+        self.set(self.colormap)
+        if (self.delta >= 1) or (self.delta <= 0):
+            self.delta_t *= -1
+
+
+class ColorFade(ColorMapFade):
     """Represents a dynamic Color that fades linearly over time between to specificed colors.
 
     knobs:
@@ -55,38 +143,15 @@ class ColorFade(Color):
     """
 
     def __init__(self, start=Color(0.0, 0.0, 0.0), finish=Color(1.0, 1.0, 1.0), time=30):
-        super().__init__(r=start.r, g=start.g, b=start.b, a=start.a, name='color_fade')
+        super().__init__(colormap=ColorMap(colormap=[ColorMapStep(0, start), ColorMapStep(1, finish)]),
+                         time=time,
+                         name='color_fade')
         self.start = start
         self.finish = finish
-        self.delta_t = time
-        self.delta_r = (finish.r - start.r) / time
-        self.delta_g = (finish.g - start.g) / time
-        self.delta_b = (finish.b - start.b) / time
 
     def __repr__(self):
-        return "ColorFade(start={}, finish={})".format(self.start, self.finish)
+        return "ColorFade(start={}, finish={}, time={})".format(self.start, self.finish, self.time)
 
     def next(self):
-        self.r += self.delta_r
-        self.g += self.delta_g
-        self.b += self.delta_b
-        
-        # correct for rounding errors that may cause us to exceed bounds
-        if (self.r <= 0):
-            self.r = 0
-            self.delta_r *= -1
-        if (self.r >= 1):
-            self.r = 1
-            self.delta_r *= -1
-        if (self.g <= 0):
-            self.g = 0
-            self.delta_g *= -1
-        if (self.g >= 1):
-            self.g = 1
-            self.delta_g *= -1
-        if (self.b <= 0):
-            self.b = 0
-            self.delta_b *= -1
-        if (self.b >= 1):
-            self.b = 1
-            self.delta_b *= -1
+        super().next()
+

--- a/python/mp/color.py
+++ b/python/mp/color.py
@@ -57,15 +57,36 @@ ColorMapStep = namedtuple('ColorMapStep', 'step color')
 
 class ColorMap(Color):
     """
-    Defines a linear color map, mapping a range to a color.
-    By convention I expect we will use the range (0,1) but any range is possible.
+    ColorMap is a special case of Color() that defines a linear color map, mapping a range to a color.
+    By convention I expect we will use the range (0,1) but any range is actually possible.
 
-    The map is defined as an array of ColorMapStep, which maps a value to a color.
+    The map is defined as a list of ColorMapStep, which maps a value to a color.
     If the value we map is between two ColorMapStep the linear interpolation is calculated.
 
     The ColorMap is a Color object - you can set r, g, b and a just like any other Color object.
     However, it is intended that the color is set using map(), which maps a value in the
     defined range to a color.
+
+    e.g.:
+    # default color map is black to 100% white
+    cm = ColorMap()
+    # set bead.color to 43% gray
+    bead.color.set(cm.map(0.43))
+
+    Example colormap covering all possible RGB colors, with both 0 and 1 set to 100% blue:
+    [
+      ColorMapStep(step=0,   color=Color(1, 0, 0)),
+      ColorMapStep(step=1/3, color=Color(0, 1, 0)),
+      ColorMapStep(step=2/3, color=Color(0, 0, 1)),
+      ColorMapStep(step=1,   color=Color(1, 0, 0))
+    ]                                                                           
+
+    Alpha channel can also be defined in the colormap.
+    For example, to map a range from 100% transparent to 100% opaque, do this:
+    [
+      ColorMapStep(step=0, color=Color(0, 0, 0, 0)),
+      ColorMapStep(step=1, color=Color(0, 0, 0, 1))
+    ]
     """
 
     def __init__(self, colormap=[ColorMapStep(0, Color(0, 0, 0)), ColorMapStep(1, Color(1, 1, 1))]):
@@ -114,6 +135,9 @@ class ColorMap(Color):
 
 
 class ColorMapFade(Color):
+    """
+    ColorMapFade() is a dynamic Color() which cycles through a provided ColorMap() over time steps.
+    """
     def __init__(self, colormap=ColorMap(colormap=[ColorMapStep(0, Color(0, 0, 0)), ColorMapStep(1, Color(1, 1, 1))]), time=30, name='color_map_fade'):
         super().__init__(r=colormap.colormap[0].color.r,
                          g=colormap.colormap[0].color.g,
@@ -137,6 +161,7 @@ class ColorMapFade(Color):
 
 class ColorFade(ColorMapFade):
     """Represents a dynamic Color that fades linearly over time between to specificed colors.
+    This is now implemented as a trivial case of ColorMapFade.
 
     knobs:
     time: number of steps to complete one color fade

--- a/python/mp/rosary.py
+++ b/python/mp/rosary.py
@@ -149,6 +149,9 @@ class Rosary:
         # some useful predefined colors
         self.color_registry = {
             'white': color.Color(1,1,1,1),
+            'tungsten100': color.Color(1, 214/255, 170/255),
+            'tungsten40': color.Color(1, 197/255, 143/255),
+            'candle': color.Color(1, 147/255, 41/255),
             'red': color.Color(1,0,0,1),
             'yellow': color.Color(1,1,0,1),
             'green': color.Color(0,1,0,1),


### PR DESCRIPTION
This defines two new `Color()` objects: `ColorMap()` and `ColorMapFade()`. `ColorMap()` defines a linear range of colors by specifying a list of the ColorMapStep named tuple. For example, to map from transparent to opaque blue, then to opaque red, do this:
```
cm = ColorMap(colormap=[ColorMapStep(0, Color(0, 0, 1, 0)), ColorMapStep(0.5, Color(0, 0, 1, 1)), ColorMapStep(1, Color(1, 0, 0, 1))])
```
This allows us to map from a floating point number to a color in a defined range by using the `map()` method, like this:
`bead.color.set(cm.map(0.3))`

`ColorMapFade()` is like `ColorFade()`, but accepts a `ColorMap()` as an argument and dynamically fades over the specified time period.

`ColorFade()` is re-implemented as a special case of `ColorMapFade()`