### PR TITLE
- Well, I don't know what "idle" and "test" actually look like, but I…

### DIFF
--- a/python/mp/effects/bin.py
+++ b/python/mp/effects/bin.py
@@ -66,14 +66,17 @@ class Bin(effect.Effect):
 
             self.effects.remove(effect)
 
-    def clear_effects(self):
+    def clear_effects(self, full=False):
         """Remove all active effects. This stops all activity on the rosary."""
-        # There's some weird race condition where del_effect's call to
-        # self.effects.remove doesn't reorder the list in time if we use
-        # a for loop, so do this instead
-        while self.effects:
-            effect = self.effects[0]
-            self.del_effect(effect.id)
+
+        # My previous issue with using a for loop instead of a while loop
+        # could just be solved by iterating over the list backwards
+        for eff in reversed(self.effects):
+            # Require an extra flag to remove the "idle" and "test" effects
+            if not full and eff.name in ("idle", "test"):
+                continue
+            else:
+                self.del_effect(eff.id)
 
     def clear_effects_fade(self):
         """

--- a/python/mp/rosary.py
+++ b/python/mp/rosary.py
@@ -502,8 +502,8 @@ class Rosary:
         self.bin.del_effect(id)
 
     @dm.expose()
-    def clear_effects(self):
-        self.bin.clear_effects()
+    def clear_effects(self, full=False):
+        self.bin.clear_effects(full)
         
     @dm.expose()
     def clear_effects_fade(self):

--- a/python/server.py
+++ b/python/server.py
@@ -30,6 +30,8 @@ def print_dispatcher_paths(unused_addr, args):
     print("* EFFECT KNOB PATHS *")
     for k in r.knobs.keys():
         print("/effect/{}".format(k))
+    print("*** RUNNING EFFECTS ***")
+    print(r.bin.effects)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…'m pretty sure I kept them alive

- The change in server.py allows `oscsend 192.168.1.5 5006 /paths` to show running effects, and the following seem to work:

`oscsend 192.168.1.5 5006 /rosary/clear_effects` now leaves effects named "idle" and "test" alone
`oscsend 192.168.1.5 5006 /rosary/clear_effects/full/True` deletes everything (what clear_effects used to do)