### PR TITLE
- Add a supervisord.conf.txt that I'm reasonably certain will work

### DIFF
--- a/python/mp/rosary.py
+++ b/python/mp/rosary.py
@@ -304,7 +304,7 @@ class Rosary:
 
     def power_mode_loop(self):
         print("Starting loop to update + backup power mode state")
-        while True:
+        while (self.run_mainloop):
             self.power_mode_updater.update()
             time.sleep(10)
     

--- a/python/supervisord.conf.txt
+++ b/python/supervisord.conf.txt
@@ -1,0 +1,45 @@
+
+; My own supervisord.conf tells me it'll look in /etc/supervisor/conf.d/*.conf
+; so if your install says that, maybe you can just put this file in that
+; directory wholesale. Otherwise, the following ought to do:
+;
+; sudo apt-get install supervisord
+; sudo tee /etc/supervisord.conf < supervisord.conf.txt
+; sudo service supervisord restart
+;
+; Most of the values I'm including are the default ones and can be omitted,
+; but I figured they might be interesting. I'm leaving the logging lines
+; for you to uncomment, if desired.
+
+[program:dmx_lighting]
+command=/home/orangepi/start-ola.sh
+autostart=true
+startretries=1000
+autorestart=true
+user=orangepi
+;redirect_stderr=true
+;stdout_logfile=/tmp/dmx_lighting.log
+;stdout_logfile_maxbytes=5MB
+;stdout_logfile_backups=0
+
+[program:rosary_server]
+command=python3 server.py --listen-ip 192.168.1.110 --ip=239.0.0.1
+directory=/root/src/MegaPrayer-oscled/python
+autostart=true
+startretries=1000
+autorestart=true
+;redirect_stderr=true
+;stdout_logfile=/tmp/rosary_server.log
+;stdout_logfile_maxbytes=5MB
+;stdout_logfile_backups=0
+
+[program:time_server]
+command=python3 time_server.py --listen-ip 192.168.1.110
+directory=/root/src/MegaPrayer-oscled/python/time_server
+autostart=true
+startretries=1000
+autorestart=true
+;redirect_stderr=true
+;stdout_logfile=/tmp/time_server.log
+;stdout_logfile_maxbytes=5MB
+;stdout_logfile_backups=0


### PR DESCRIPTION
- Have the low power mode thread exit on rosary.run_mainloop == False

@jdblair Since the low power thread is sleeping for 10 seconds at a time, you'll probably still end up pressing ctrl+c. But it does at least exit along with mainloop now.

I tried to transcribe your comments into supervisord.conf.txt. After changing directories to my own, I'm at least pretty sure the python ones work. The DMX thing is completely untested.

I think all you really ahve to do is `sudo apt-get install supervisor` on the orangepi, and the installation sets up the autorun of supervisor itself.